### PR TITLE
edit: explications pour produire le format PDF depuis LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ Le modèle Microsoft Word est disponible dans ce dépôt à l'adresse [`word/hum
 
 Les auteurs ne peuvent pas modifier ces fichiers de style ou utiliser des modèles conçus pour d'autres conférences.
 
+## Instructions pour produire le format PDF depuis LaTeX
+
+Voici les commandes nécessaires à la production du format PDF :
+
+- prérequis : disposer le texte source `votre-texte.tex` dans un dossier aux côtés des fichiers fournis ici
+- `pdflatex votre-texte.tex`
+- `bibtex votre-texte.aux`
+- `pdflatex votre-texte.tex`
+- `pdflatex votre-texte.tex` (parce que 🤷)
+
+Bonus : pour les personnes travaillant avec Markdown il est possible d'utiliser Pandoc pour transformer la source en `.tex` puis faire quelques modifications manuelles :
+
+- `pandoc -f markdown -t latex votre-texte.md -o votre-texte.tex`
+- remplacer les citations avec ces deux regex :
+  - `\{\[\}@(.*?)\{\]\}` → `\citep{$1}`
+	- `\\_` → `_`
+- ajouter l'entête du document LaTeX ainsi que le footer
+- suivre la procédure ci-dessus pour produire le PDF
+
+
 ## Crédits
 
 Ces modèles dérivent de ceux utilisés par les conférences d'[ACL](https://github.com/gabays/acl-style-files).


### PR DESCRIPTION
Ces explications faciliteront peut-être la vie des personnes qui souhaitent utiliser le template LaTeX. Avec un bonus pour passer par Markdown + Pandoc.